### PR TITLE
[fix] changing tokenizer interface preprocessing script

### DIFF
--- a/download_prepare/transform_tokenize.py
+++ b/download_prepare/transform_tokenize.py
@@ -11,7 +11,8 @@ def main():
     try:
         tokenizer = AutoTokenizer.from_pretrained(args.pretrained_model)
     except:
-        tokenizer = BertTokenizer.from_pretrained(args.pretrained_model)
+        tokenizer = BertWordPieceTokenizer(vocab=args.pretrained_model+ "/vocab.txt", lowercase=False, clean_text=False, handle_chinese_chars=False)
+        tokenizer.tokenize = lambda x: tokenizer.encode(x, add_special_tokens=False).tokens
     fo = open(args.input, encoding="utf-8")
     fw = open(args.output, "w", encoding="utf-8")
     line = fo.readline()


### PR DESCRIPTION
The current implementation in this file applies lowercase automatically since it is using BertTokenizer interface from huggingface/transformers with default settings. This PR should fix this issue.